### PR TITLE
fix initialization on web

### DIFF
--- a/lib/client_information_web.dart
+++ b/lib/client_information_web.dart
@@ -136,11 +136,11 @@ class ClientInformationWeb {
     var cookieStr = html.window.document.cookie;
     if (cookieStr == null || cookieStr == '') return null;
 
-    return cookieStr
+    var el = cookieStr
         .split('; ')
-        .firstWhere((row) => row.startsWith(similar ? key : '$key='))
-        .split('=')
-        .elementAt(1);
+        .firstWhere((row) => row.startsWith(similar ? key : '$key='), orElse: () => '')
+        .split('=');
+    return el.length > 1 ? el.elementAt(1) : null;
   }
 
   _Software _getOS() {

--- a/lib/client_information_web.dart
+++ b/lib/client_information_web.dart
@@ -40,7 +40,7 @@ class ClientInformationWeb {
 
     var applicationType = 'web';
     var applicationVersion = 'unknown_version';
-    var applicationBuildCode = 0;
+    var applicationBuildCode = '0';
     var applicationName = 'unknown_name';
 
     var _appMapData = await _getVersionJsonData();
@@ -74,7 +74,7 @@ class ClientInformationWeb {
     resultInfo['applicationType'] = applicationType;
     resultInfo['applicationName'] = applicationName;
     resultInfo['applicationVersion'] = applicationVersion;
-    resultInfo['applicationBuildCode'] = applicationBuildCode.toString();
+    resultInfo['applicationBuildCode'] = applicationBuildCode;
     return Future.value(resultInfo);
   }
 


### PR DESCRIPTION
The PR fixes two issues with initializing the plugin on web.
   - applicationBuildCode initial value changed to string, because the build_number reported by flutter is a string. ( see https://github.com/Kent1011/client_information/issues/1 )
   - _getCookieValue is modified to handle the case of a cookie being not empty but also not containing the requested key.